### PR TITLE
Working source-maps!

### DIFF
--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -10,5 +10,8 @@ try {
         console.log(result)
     }, function(err) {
         console.log(err)
+    })['catch'](function(err) {
+        console.log('ERROR!');
+        console.log(err);
     })
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ var BUILD_DIR = path.join(__dirname, 'build')
 var config =
     { context: path.join(__dirname, 'src')
     , devServer: { contentBase: BUILD_DIR }
+    , devtool: '#source-map'
     , entry: './scripts/index.js'
     , module:
         { loaders:


### PR DESCRIPTION
I fixed stacktrace-gps (stacktrace.js dependency) to return source-mapped location even if other analysis fails. 

Your example should really work with no changes other than making sure you have the latest stacktracejs/stacktrace.js#master
